### PR TITLE
add line art (edge detect) comparison mode

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,79 @@
+/**
+ * @param data - input pixels data
+ * @param idx - the index of the central pixel
+ * @param w - image width (width*4 in case of RGBA)
+ * @param m - the gradient mask (for Sobel=[1, 2, 1])
+ */
+function conv3x(data, idx, w, m) {
+  return (
+    m[0] * data[idx - w - 4] +
+    m[1] * data[idx - 4] +
+    m[2] * data[idx + w - 4] -
+    m[0] * data[idx - w + 4] -
+    m[1] * data[idx + 4] -
+    m[2] * data[idx + 4 + 4]
+  )
+}
+
+function conv3y(data, idx, w, m) {
+  return (
+    m[0] * data[idx - w - 4] +
+    m[1] * data[idx - w] +
+    m[2] * data[idx - w + 4] -
+    (m[0] * data[idx + w - 4] + m[1] * data[idx + w] + m[2] * data[idx + w + 4])
+  )
+}
+
+/**
+ * @param pixels - Object of image parameters
+ * @param mask - gradient operator e.g. Prewitt, Sobel, Scharr, etc.
+ */
+function gradient_internal(pixels, mask) {
+  var data = pixels.data
+  var w = pixels.width * 4
+  var l = data.length - w - 4
+  var buff = new data.constructor(new ArrayBuffer(data.length))
+
+  for (var i = w + 4; i < l; i += 4) {
+    var dx = conv3x(data, i, w, mask)
+    var dy = conv3y(data, i, w, mask)
+    buff[i] = buff[i + 1] = buff[i + 2] = Math.sqrt(dx * dx + dy * dy)
+    buff[i + 3] = 255
+  }
+  pixels.data.set(buff)
+}
+
+/**
+ * @param canvas - HTML5 Canvas elementFromPoint
+ */
+export const edge_detect = function (canvas) {
+  var context = canvas.getContext('2d')
+  var pixels = context.getImageData(0, 0, canvas.width, canvas.height)
+  gradient_internal(pixels, [1, 2, 1]) // Apply Sobel operator
+  context.putImageData(pixels, 0, 0)
+}
+
+/**
+ * @param canvas - HTML5 Canvas elementFromPoint
+ * @param colorHex - color to replace black pixels with (no hash symbol)
+ */
+// Map white pixels to white, and black pixels to specified color
+export const colorize = function (canvas, colorHex) {
+  var context = canvas.getContext('2d')
+  var pixels = context.getImageData(0, 0, canvas.width, canvas.height)
+  var data = pixels.data
+  var l = data.length
+  var bigint = parseInt(colorHex, 16)
+  var color = { r: (bigint >> 16) & 255, g: (bigint >> 8) & 255, b: bigint & 255 }
+  console.log(colorHex)
+  console.log(JSON.stringify(color))
+  for (var i = 0; i < l; i += 4) {
+    // knock out alpha in white areas
+    data[i + 3] = data[i]
+    // set pixel colour to specified colour
+    data[i] = color.r
+    data[i + 1] = color.g
+    data[i + 2] = color.b
+  }
+  context.putImageData(pixels, 0, 0)
+}

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -74,6 +74,13 @@
           <button @click="prevGlobalCompositeOperation">-</button>
           <button @click="nextGlobalCompositeOperation">+</button>
         </div>
+        <div class="_advanced">
+          <label>Image style</label>
+          <select v-model="canvas_image_style">
+            <option value="photo">Photo</option>
+            <option value="line">Outline</option>
+          </select>
+        </div>
       </details>
 
       <div class="_madeBy">
@@ -113,10 +120,12 @@
         <small>Click on two bikes or more in the sidebar to compare their size</small>
       </div>
       <canvas ref="bikes" width="1920" height="1920" />
+      <canvas ref="processor" width="1920" height="1920" style="display: none" />
     </div>
   </div>
 </template>
 <script>
+import { edge_detect, colorize } from '../helpers.js'
 export default {
   props: {
     bikes: Array
@@ -157,7 +166,9 @@ export default {
         'saturation',
         'color',
         'luminosity'
-      ]
+      ],
+
+      canvas_image_style: 'photo'
     }
   },
   created() {},
@@ -178,6 +189,17 @@ export default {
     },
     canvas_composite_operation: {
       handler() {
+        this.showBikes()
+      }
+    },
+    canvas_image_style: {
+      handler() {
+        // could add these defaults in if desired
+        // if (this.canvas_image_style === 'line') {
+        //   this.canvas_composite_operation = 'multiply'
+        // } else {
+        //   this.canvas_composite_operation = 'source-over'
+        // }
         this.showBikes()
       }
     },
@@ -317,7 +339,42 @@ export default {
 
         const draw_y = canvas.height - padding - draw_h + bike.bottom_margin_percent * draw_h
 
-        ctx.drawImage(img, draw_x, draw_y, draw_w, draw_h)
+        if (this.canvas_image_style === 'line') {
+          // Offscreen canvas for edge detection on the image
+          const processorCanvas = this.$refs.processor
+          if (!processorCanvas) return
+
+          processorCanvas.width = Math.min(
+            processorCanvas.parentNode.clientWidth * window.devicePixelRatio,
+            processorCanvas.parentNode.clientHeight * window.devicePixelRatio * 1.5
+          )
+          processorCanvas.height = Math.min(
+            processorCanvas.parentNode.clientHeight * window.devicePixelRatio,
+            processorCanvas.width
+          )
+
+          const processorCtx = processorCanvas.getContext('2d')
+          processorCtx.globalCompositeOperation = 'source-over'
+
+          // white BG for a clean edge detect result
+          processorCtx.fillStyle = 'white'
+          processorCtx.fillRect(0, 0, canvas.width, canvas.height)
+          processorCtx.drawImage(img, draw_x, draw_y, draw_w, draw_h)
+
+          // detect edges
+          edge_detect(processorCanvas)
+
+          // colorize
+          const color_options = ['11bb11', '3333ff', 'bbbb00', 'ff0000', 'ff00ff', '00bbbbb']
+          // find the index of the current bike
+          const index = this.enabled_bikes.indexOf(bike.id)
+          const color = color_options[index % color_options.length]
+          colorize(processorCanvas, color)
+
+          ctx.drawImage(processorCanvas, 0, 0, processorCanvas.width, processorCanvas.height)
+        } else {
+          ctx.drawImage(img, draw_x, draw_y, draw_w, draw_h)
+        }
       }
 
       // repère


### PR DESCRIPTION
Here's a pitch for adding line art functionality. It adds another offscreen canvas where we process the existing images to generate colorized outlines, before adding them to the primary canvas.

In future it could be improved with a canvas filter or webGL implementation if performance turns out to be too rough, but it seems to work ok in my testing.

I've included an optional default for blending mode depending on whether Photo or Line mode is selected (it's currently commented out).

Thanks!